### PR TITLE
Update scala benchmarks to be compatible with Akka 2.5

### DIFF
--- a/src/scala/actor_creation.scala
+++ b/src/scala/actor_creation.scala
@@ -3,6 +3,8 @@ package org.caf.scala
 import org.caf.scala.utility._
 
 import akka.actor._
+import scala.concurrent.duration.Duration
+import scala.concurrent.Await
 
 case class Spread(value: Int)
 case class Result(value: Int)
@@ -28,7 +30,7 @@ class Testee(parent: ActorRef) extends Actor {
                   System.exit(42)
                 }
                 context.stop(self)
-                global_latch countDown
+                global_latch.countDown
               } else {
                 parent ! Result(1 + r1 + r2)
                 context.stop(self)
@@ -47,7 +49,7 @@ object actor_creation {
       val system = ActorSystem()
       system.actorOf(Props(new Testee(null))) ! Spread(n)
       global_latch.await
-      system.shutdown
+      Await.result(system.terminate, Duration.Inf)
       System.exit(0)
     }
     case _ => usage

--- a/src/scala/distributed.scala
+++ b/src/scala/distributed.scala
@@ -172,16 +172,21 @@ object distributed {
     def main(args: Array[String]): Unit = args match {
         case Array("mode=server") => runServer
         // client mode
-        case Array("mode=benchmark", _*) => runBenchmark(args.toList.drop(2))
+        case Array("mode=benchmark", _*) => {
+          runBenchmark(args.toList.drop(1))
+        }
         // error
         case _ => {
             println("Running in server mode:\n"                              +
                     "  mode=server\n"                                        +
-                    "  remote_actors PORT *or* akka\n"                       +
                     "\n"                                                     +
                     "Running the benchmark:\n"                               +
                     "  mode=benchmark\n"                                     +
-                    "  remote_actors ... *or* akka\n"                         );
+                    "  num_pings=NUM\n"                                      +
+                    "  PONG_ACTOR1 PONG_ACTOR2 [...]\n"                      +
+                    "\n"                                                     +
+                    "  where PONG_ACTOR is an actor path anchor, e.g.,\n"    +
+                    "  akka.tcp://pongServer@hostname:2552/user/pong")
         }
     }
 

--- a/src/scala/distributed.scala
+++ b/src/scala/distributed.scala
@@ -1,54 +1,42 @@
 package org.libcppa
 
-import org.libcppa.utility._
+import org.caf.scala.utility._
 
 import akka.actor._
 import com.typesafe.config.ConfigFactory
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._
+import scala.concurrent.Await
 
 import Console.println
 
 case class Ping(value: Int)
 case class Pong(value: Int)
+case class PingKickOff(value: Int, pong: ActorRef)
 case class KickOff(value: Int)
 
 case object Done
 case class Ok(token: String)
-case class Hello(token: String)
-case class Olleh(token: String)
-case class Error(msg: String, token: String)
-case class AddPong(path: String, token: String)
-case class SetParent(parent: ActorRef)
+case class AddPong(peerRef: ActorRef, token: String)
 
 
-case class AddPongTimeout(path: String, token: String)
-
-case class Peer(path: String, channel: ActorRef)
-case class Peers(connected: List[Peer], pending: List[PendingPeer])
-case class PendingPeer(path: String, channel: ActorRef, client: ActorRef, clientToken: String)
-
-class PingActor(pongs: List[ActorRef]) extends Actor {
+class PingActor(parent: ActorRef) extends Actor {
 
     import context.become
-
-    private var parent: ActorRef = null
-    private var left = pongs.length
 
     private final def recvLoop: Receive = {
         case Pong(0) => {
             parent ! Done
-            //println(parent.toString + " ! Done")
-            if (left > 1) left -= 1
-            else context.stop(self)
+            context.stop(self)
         }
         case Pong(value) => sender ! Ping(value - 1)
     }
 
     def receive = {
-        case SetParent(p) => parent = p
-        case KickOff(value) => pongs.foreach(_ ! Ping(value)); become(recvLoop)
+        case PingKickOff(value, pongServer) => {
+          pongServer ! Ping(value); become(recvLoop)
+        }
     }
 }
 
@@ -56,70 +44,25 @@ class ServerActor(system: ActorSystem) extends Actor {
 
     import context.become
 
-    private final def reply(what: Any): Unit = sender ! what
+    private var peers = Set.empty[ActorRef]
 
-    private final def kickOff(peers: Peers, value: Int): Unit = {
-        val ping = context.actorOf(Props(new PingActor(peers.connected map (_.channel))))
-        ping ! SetParent(sender)
-        ping ! KickOff(value)
-        //println("[" + peers + "]: KickOff(" + value + ")")
-    }
-
-    private final def connectionEstablished(peers: Peers, x: Any): Peers = x match {
-        case PendingPeer(path, channel, client, token) => {
-            client ! Ok(token)
-            //println("connected to " + path)
-            Peers(Peer(path, channel) :: peers.connected, peers.pending filterNot (_.clientToken == token))
-        }
-    }
-
-    private final def newPending(peers: Peers, path: String, token: String) : Peers = {
-        import context.dispatcher // Use this Actors' Dispatcher as ExecutionContext
-        val channel = system.actorFor(path)
-        channel ! Hello(token)
-        system.scheduler.scheduleOnce(5 seconds, self, AddPongTimeout(path, token))
-        //println("[" + peers + "]: sent 'Hello' to " + path)
-        Peers(peers.connected, PendingPeer(path, channel, sender, token) :: peers.pending)
-    }
-
-    private final def handleAddPongTimeout(peers: Peers, path: String, token: String) = {
-        peers.pending find (x => x.path == path && x.clientToken == token) match {
-            case Some(PendingPeer(_, channel, client, _)) => {
-                client ! Error(path + " did not respond", token)
-                //println(path + " did not respond")
-                become(bhvr(Peers(peers.connected, peers.pending filterNot (x => x.path == path && x.clientToken == token))))
+    def receive = {
+        case Ping(value) => sender ! Pong(value)
+        case AddPong(peerRef, token) => {
+            if (!peers.contains(peerRef)) {
+                context.watch(peerRef)
+                peers += peerRef
             }
-            case None => Unit
+            sender ! Ok(token)
+        }
+        case KickOff(value) => {
+          // For each peer, spawn a PingActor to ping that peer.
+          peers foreach { p =>
+              val ping = context.actorOf(Props(classOf[PingActor], sender))
+              ping ! PingKickOff(value, p)
+          }
         }
     }
-
-    def bhvr(peers: Peers): Receive = {
-        case Ping(value) => reply(Pong(value))
-        case Hello(token) => reply(Olleh(token))
-        case Olleh(token) => peers.pending.find (_.clientToken == token) match {
-            case Some(x) => connectionEstablished(peers, x); become(bhvr(peers))
-            case None => Unit
-        }
-        case AddPong(path, token) => {
-            //println("received AddPong(" + path + ", " + token + ")")
-            if (peers.connected exists (_.path == path)) {
-                reply(Ok(token))
-                //println("recv[" + peers + "]: " + path + " cached (replied 'Ok')")
-            }
-            else {
-                try { become(bhvr(newPending(peers, path, token))) }
-                catch {
-                    // catches match error and integer conversion failure
-                    case e : Exception => reply(Error(e.toString, token))
-                }
-            }
-        }
-        case KickOff(value) => kickOff(peers, value)
-        case AddPongTimeout(path, token) => handleAddPongTimeout(peers, path, token)
-    }
-
-    def receive = bhvr(Peers(Nil, Nil))
-
 }
 
 case class TokenTimeout(token: String)
@@ -133,6 +76,7 @@ class ClientActor(system: ActorSystem) extends Actor {
         case Done => {
 //println("Done")
             if (left == 1) {
+                context.system.log.info("Benchmark complete")
                 global_latch.countDown
                 context.stop(self)
             } else {
@@ -158,32 +102,33 @@ class ClientActor(system: ActorSystem) extends Actor {
         }
         case TokenTimeout(token) => {
             if (!receivedTokens.contains(token)) {
-                println("Error: " + token + " did not reply within 10 seconds")
+                context.system.log.error("Error: " + token + " did not reply within 10 seconds")
                 global_latch.countDown
                 context.stop(self)
             }
         }
-        case Error(what, token) => {
-            println("Error [from " + token+ "]: " + what)
-            global_latch.countDown
-            context.stop(self)
-        }
     }
 
     def receive = {
+        // Start the benchmark by sending n-1 AddPong messages to each pong server,
+        // where n is the number of servers. Each server's path is listed in `paths`.
         case RunClient(paths, numPings) => {
 //println("RunClient(" + paths.toString + ", " + numPings + ")")
-            val pongs = paths map (x => {
-                val pong = system.actorFor(x)
-                paths foreach (y => if (x != y) {
-                    val token = x + " -> " + y
-                    pong ! AddPong(y, token)
-//println(x + " ! AddPong(" + y + ", " + token + ")")
-                    import context.dispatcher // Use this Actors' Dispatcher as ExecutionContext
-                    system.scheduler.scheduleOnce(10 seconds, self, TokenTimeout(token))
-                })
-                pong
-            })
+
+            // Resolve ActorRefs to all pong servers.
+            val t = 5.seconds
+            val pongs = paths map (p =>
+                Await.result(context.actorSelection(p).resolveOne(t), t)
+            )
+
+            // Start sending off AddPong.
+            for { p1 <- pongs; p2 <- pongs; if p1 != p2 } {
+                val token = p1.path.toStringWithAddress(p1.path.address) + " -> " + p2.path.toStringWithAddress(p2.path.address)
+                p1 ! AddPong(p2, token)
+                import context.dispatcher // Use this Actors' Dispatcher as ExecutionContext
+                system.scheduler.scheduleOnce(10.seconds, self, TokenTimeout(token))
+            }
+
             become(collectOkMessages(pongs, pongs.length * (pongs.length - 1), Nil, numPings))
         }
     }
@@ -219,7 +164,7 @@ object distributed {
             val system = ActorSystem("benchmark", ConfigFactory.load.getConfig("benchmark"))
             system.actorOf(Props(new ClientActor(system))) ! RunClient(paths, x)
             global_latch.await
-            system.shutdown
+            Await.result(system.terminate, Duration.Inf)
             System.exit(0)
         }))
     }

--- a/src/scala/mailbox_performance.scala
+++ b/src/scala/mailbox_performance.scala
@@ -4,6 +4,8 @@ import org.caf.scala.utility._
 
 import akka.actor._
 import scala.annotation.tailrec
+import scala.concurrent.duration.Duration
+import scala.concurrent.Await
 
 case object Msg
 case object RunSender
@@ -42,7 +44,7 @@ object mailbox_performance {
                 //}).start
             }
             global_latch.await
-            system.shutdown
+            Await.result(system.terminate, Duration.Inf)
             System.exit(0)
         }
         case _ => usage

--- a/src/scala/mandelbrot.scala
+++ b/src/scala/mandelbrot.scala
@@ -13,6 +13,8 @@ import org.caf.scala.utility._
 
 import Array._
 import java.io.BufferedOutputStream
+import scala.concurrent.duration.Duration
+import scala.concurrent.Await
 
 object mandelbrot {
 
@@ -70,7 +72,7 @@ object mandelbrot {
           x += 1
         }
         context stop self
-        global_latch countDown
+        global_latch.countDown
       }
     }
   }
@@ -97,7 +99,7 @@ object mandelbrot {
       //  y += 1
       //}
       //w.close
-      system.shutdown
+      Await.result(system.terminate, Duration.Inf)
       System.exit(0)
     }
     case _ => usage

--- a/src/scala/matching.scala
+++ b/src/scala/matching.scala
@@ -1,6 +1,6 @@
 package org.libcppa
 
-import org.libcppa.utility._
+import org.caf.scala.utility._
 
 import Console.println
 import scala.{PartialFunction => PF}

--- a/src/scala/mixed_case.scala
+++ b/src/scala/mixed_case.scala
@@ -4,6 +4,8 @@ import org.caf.scala.utility._
 
 import akka.actor._
 import scala.annotation.tailrec
+import scala.concurrent.duration.Duration
+import scala.concurrent.Await
 
 case class Token(value: Int)
 
@@ -118,7 +120,7 @@ object mixed_case {
             val s = system.actorOf(Props(new Supervisor(numMessages, numRings, ringSize, initToken, reps)))
             s ! Init
             global_latch.await
-            system.shutdown
+            Await.result(system.terminate, Duration.Inf)
             System.exit(0)
         }
         case _ => usage

--- a/src/scala/utility.scala
+++ b/src/scala/utility.scala
@@ -11,9 +11,9 @@ object utility {
     }
 
     object KeyValuePair {
-        val Rx = "([^=])+=([^=]*)".r
-        def unapply(s: String): Option[Pair[String, String]] = s match {
-            case Rx(key, value) => Some(Pair(key, value))
+        val Rx = "([^=]+)=([^=]*)".r
+        def unapply(s: String): Option[(String, String)] = s match {
+            case Rx(key, value) => Some((key, value))
             case _ => None
         }
     }


### PR DESCRIPTION
This updates the scala benchmarks to be compatible with a recent version of akka (tested with akka version 2.5.12 and scala version 2.12.6). Most of the benchmarks required relatively small adaptations to compile with newer versions of akka.

Most notably, `ActorSystem.shutdown` has been replaced by `ActorSystem.terminate`. `actorFor` is deprecated in favor of actorSelection since akka version 2.2 (July 2013) (ultimately to be removed somewhere down the road - `actorFor` does no longer exist).

Furthermore, this also includes a correction of the scala distributed benchmark (as well as simplification). It did not have the same shape as the other distributed benchmarks with respect to messaging patterns number of actors (apart from neither compiling nor parsing the command line properly). These changes makes the scala distributed benchmark mimic the caf and erlang implementations closely.
